### PR TITLE
Update footer.html

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,2 @@
-</main>
-	
-{{partial "pnpstyles/organisms-footer-footer.html" . }}
 
-</body>
-</html>
+{{partial "pnpstyles/organisms-footer-footer.html" . }}


### PR DESCRIPTION
Removed extra closing main, body and html tags

I have discovered on the PnP Site, the view source reveals there is a extra closing main, body and html tags. 

![image](https://github.com/user-attachments/assets/9c3d6a1e-4566-4667-beee-aa7347c92508)

@hugoabernier - when you have a moment, are you able to test site generation and see if it breaks anything please?